### PR TITLE
cleanup compile

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -7,6 +7,20 @@ var bs2tokenizer = require('pbasic-tokenizer');
 
 var serial = require('./serial');
 
+function internalCompile(options){
+  var TModuleRec = bs2tokenizer.compile(options.source, false);
+
+  if(!TModuleRec.Succeeded){
+    throw new Error('Compile error: ' + TModuleRec.Error);
+  }
+
+  var memory = {
+    data: TModuleRec.PacketBuffer.slice(0, TModuleRec.PacketCount * 18)
+  };
+
+  return memory;
+}
+
 function bootload(options, cb){
 
   if(!options){
@@ -36,18 +50,7 @@ function bootload(options, cb){
 }
 
 function compile(options, cb){
-
-  var TModuleRec = bs2tokenizer.compile(options.source, false);
-
-  if(!TModuleRec.Succeeded){
-    throw new Error('Compile error: ', TModuleRec.Error);
-  }
-
-  var memory = {
-    data: TModuleRec.PacketBuffer.slice(0, TModuleRec.PacketCount * 18)
-  };
-
-  var result = bluebird.resolve(memory);
+  var result = bluebird.try(internalCompile, options);
 
   return result.nodeify(cb);
 }


### PR DESCRIPTION
we should only throw on errors in passed arguments, not from the compile
bluebird.try turns the throw into a rejected promise that we can nodeify
