### PR TITLE
Add search functionality to board interface

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var bs2 = require('bs2-programmer');
 var through = require('through2');
 var bluebird = require('bluebird');
@@ -55,6 +56,40 @@ function Board(options){
   });
 }
 
+Board.search = function(portList, cb){
+  var revisions = _.keys(bs2.revisions);
+  return bluebird.reduce(portList, function(boardList, port){
+
+    var protocol = new Bs2SerialProtocol({ path: port });
+    return bluebird.reduce(revisions, function(current, rev){
+      if(current){
+        return current;
+      }
+
+      var boardOpts = {
+        protocol: protocol,
+        revision: rev
+      };
+
+      return bs2.identify(boardOpts)
+        .then(function(result){
+          return _.assign({ port: port }, result);
+        })
+        .otherwise(function(){
+          return null;
+        });
+
+    }, null)
+    .then(function(board){
+      if(board != null){
+        boardList.push(board);
+      }
+      return boardList;
+    });
+
+  }, []).nodeify(cb);
+};
+
 Board.prototype.bootload = function(memory, cb){
   if(!memory || !memory.data){
     throw new Error('Options error: no program data');
@@ -86,10 +121,8 @@ Board.prototype.compile = function(source, cb){
   return result.nodeify(cb);
 };
 
-Board.prototype.getRevisions = function(cb){
-  var result = bluebird.resolve(bs2.revisions);
-
-  return result.nodeify(cb);
+Board.getRevisions = function(){
+  return bs2.revisions;
 };
 
 module.exports = Board;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "bluebird": "^2.9.14",
-    "bs2-programmer": "^2.0.0",
+    "bs2-programmer": "^2.1.0",
     "bs2-serial-protocol": "^0.2.0",
     "lodash": "^3.5.0",
     "pbasic-tokenizer": "^0.1.0",

--- a/test/board.js
+++ b/test/board.js
@@ -100,19 +100,23 @@ describe('bs2-serial', function(){
 
   it('#getRevisions returns an object', function(done){
 
-    var options = {
-      path: '/dev/tacos',
-      revision: 'bs2'
-    };
-
     app.register(plugins, function(){
-      // TODO: it doesn't make sense to getRevisions when you defined
-      // one in the options to the constructor
-      var board = new app.bs2serial(options);
-      board.getRevisions(function(err, revisions){
-        expect(err).toNotExist();
-        expect(revisions).toBeAn('object');
-        done();
+      expect(app.bs2serial.getRevisions()).toBeAn('object');
+      done();
+    });
+  });
+
+  it('#search processes port list and returns any found boards', function(done){
+    this.timeout(30000);
+
+    app.register(plugins, function(err){
+      expect(err).toNotExist();
+      expect(app.bs2serial).toExist();
+      expect(app.bs2serial.search).toExist();
+      app.bs2serial.search(['/dev/tty.usbserial-A502BMX2', '/dev/zero'], function(error, results){
+        expect(error).toNotExist();
+        expect(results).toExist();
+        done(error);
       });
     });
   });


### PR DESCRIPTION
#### What's this PR do?

Exposes a `search` method on the static Board object, which consumes a list of port names and attempts to identify devices on each port.
#### How should this be manually tested?

Connect a BS2 device via USB, execute a search against the ports available.
#### What are the relevant tickets?

Groundwork for parallaxinc/ChromeIDE/issues/73
