### PR TITLE
Update interface to support irken new-api changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function bs2serial(app, opts, cb){
   var namespace = opts.namespace || 'bs2serial';
 
   app.expose(namespace, board);
+  app.addBoard('bs2', board);
 
   cb();
 }

--- a/lib/board.js
+++ b/lib/board.js
@@ -58,9 +58,9 @@ function Board(options){
 
 Board.search = function(portList, cb){
   var revisions = _.keys(bs2.revisions);
-  return bluebird.reduce(portList, function(boardList, port){
+  return bluebird.reduce(portList, function(boardList, path){
 
-    var protocol = new Bs2SerialProtocol({ path: port });
+    var protocol = new Bs2SerialProtocol({ path: path });
     return bluebird.reduce(revisions, function(current, rev){
       if(current){
         return current;
@@ -73,7 +73,7 @@ Board.search = function(portList, cb){
 
       return bs2.identify(boardOpts)
         .then(function(result){
-          return _.assign({ port: port }, result);
+          return _.assign({ path: path, revision: rev }, result);
         })
         .otherwise(function(){
           return null;
@@ -82,7 +82,14 @@ Board.search = function(portList, cb){
     }, null)
     .then(function(board){
       if(board != null){
-        boardList.push(board);
+        boardList.push({
+          name: board.name,
+          path: board.path,
+          board: {
+            path: board.path,
+            revision: board.revision
+          }
+        });
       }
       return boardList;
     });


### PR DESCRIPTION
#### What's this PR do?

Updates Board interface to match expected `new-api` irken interface. Adds board definition via `app.addBoard()` and adds `board` object to search results with all needed constructor values to build new `Board` instance.
#### How should this be manually tested?

Execute board search and verify returned object structure.
#### What are the relevant tickets?

parallaxinc/ChromeIDE/issues/73
