### PR TITLE
Expose open state, close method, and download progress on Board interface

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -1,11 +1,13 @@
 'use strict';
 
 var _ = require('lodash');
+var util = require('util');
 var bs2 = require('bs2-programmer');
 var through = require('through2');
 var bluebird = require('bluebird');
-var bs2tokenizer = require('pbasic-tokenizer');
 var Bs2Programmer = bs2.Programmer;
+var bs2tokenizer = require('pbasic-tokenizer');
+var EventEmitter = require('events').EventEmitter;
 var Bs2SerialProtocol = require('bs2-serial-protocol');
 
 function parseChunk(chunk){
@@ -44,13 +46,23 @@ function Board(options){
     throw new Error('Options error: no path');
   }
 
+  EventEmitter.call(this);
+
   this._revision = options.revision || 'bs2';
   this._protocol = new Bs2SerialProtocol(options);
   this._programmer = new Bs2Programmer({
     protocol: this._protocol,
     revision: this._revision
   });
+
+  var self = this;
+
+  this._programmer.on('bootloadProgress', function(progress){
+    self.emit('progress', progress);
+  });
 }
+
+util.inherits(Board, EventEmitter);
 
 Board.search = function(portList, cb){
   var revisions = _.keys(bs2.revisions);

--- a/lib/board.js
+++ b/lib/board.js
@@ -44,10 +44,6 @@ function Board(options){
     throw new Error('Options error: no path');
   }
 
-  if(!options.revision){
-    throw new Error('Options error: no revision');
-  }
-
   this._revision = options.revision || 'bs2';
   this._protocol = new Bs2SerialProtocol(options);
   this._programmer = new Bs2Programmer({
@@ -126,6 +122,14 @@ Board.prototype.compile = function(source, cb){
   var result = bluebird.try(internalCompile, source);
 
   return result.nodeify(cb);
+};
+
+Board.prototype.isOpen = function(){
+  return !!_.get(this, '_protocol._isOpen');
+};
+
+Board.prototype.close = function(cb){
+  return this._protocol.close(cb);
 };
 
 Board.getRevisions = function(){

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "bluebird": "^2.9.14",
-    "bs2-programmer": "^2.1.0",
-    "bs2-serial-protocol": "^0.2.0",
+    "bs2-programmer": "^2.2.0",
+    "bs2-serial-protocol": "^0.3.0",
     "lodash": "^3.5.0",
     "pbasic-tokenizer": "^0.1.0",
     "through2": "^0.6.5"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "expect": "^1.6.0",
     "mocha": "^2.2.1",
-    "irken": "^0.3.0"
+    "irken": "^0.5.0"
   },
   "dependencies": {
     "bluebird": "^2.9.14",


### PR DESCRIPTION
#### What's this PR do?

This PR exposes `isOpen` and `close` methods for managing port status. Adds download `progress` events for UI.
#### What are the relevant tickets?

Depends on irkenjs/bs2-serialport/pull/6
Depends on irkenjs/bs2-programmer/pull/14
