### PR TITLE
Remove read() function, forward terminal events

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -3,25 +3,11 @@
 var _ = require('lodash');
 var util = require('util');
 var bs2 = require('bs2-programmer');
-var through = require('through2');
 var bluebird = require('bluebird');
 var Bs2Programmer = bs2.Programmer;
 var bs2tokenizer = require('pbasic-tokenizer');
 var EventEmitter = require('events').EventEmitter;
 var Bs2SerialProtocol = require('bs2-serial-protocol');
-
-function parseChunk(chunk){
-  var str = '';
-  for(var idx = 0; idx < chunk.length; idx++){
-    var char = chunk[idx];
-    if(char === 13){
-      str += '\n';
-    } else {
-      str += String.fromCharCode(char);
-    }
-  }
-  return str;
-}
 
 function internalCompile(source){
   var TModuleRec = bs2tokenizer.compile(source, false);
@@ -59,6 +45,10 @@ function Board(options){
 
   this._programmer.on('bootloadProgress', function(progress){
     self.emit('progress', progress);
+  });
+
+  this._protocol.on('terminal', function(evt){
+    self.emit('terminal', evt);
   });
 }
 
@@ -111,23 +101,6 @@ Board.prototype.bootload = function(memory, cb){
   }
 
   return this._programmer.bootload(memory.data, cb);
-};
-
-// TODO: bring this down into the protocol level
-Board.prototype.read = function(options){
-  options = options || {};
-
-  var stream = through();
-
-  this._protocol._transport.on('data', function(chunk){
-    if(options.raw){
-      return stream.write(chunk);
-    }
-
-    stream.write(parseChunk(chunk));
-  });
-
-  return stream;
 };
 
 Board.prototype.compile = function(source, cb){


### PR DESCRIPTION
#### What's this PR do?

This PR removes the `read` method and the stream output, replacing it with terminal events. It also removes the chunk parsing, moving the functionality into bs2-serialport.
#### Any background context you want to provide?

This will provide support for specialized terminal events that allow for console control character support.
#### What are the relevant tickets?

parallaxinc/ChromeIDE/issues/66
