### PR TITLE
Expose version on device scan

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -83,10 +83,8 @@ Board.search = function(portList, cb){
         boardList.push({
           name: board.name,
           path: board.path,
-          board: {
-            path: board.path,
-            revision: board.revision
-          }
+          version: board.version,
+          board: _.cloneDeep(board)
         });
       }
       return boardList;


### PR DESCRIPTION
#### What's this PR do?

Adds version code to device scan output. Also exposes the full device object that is used to instantiate Board instances.
#### Where should the reviewer start?

Scan for a list of devices, verify board version and full board object are included in output.
#### Any background context you want to provide?

Version code should be exposed to user, but this wasn't being passed along. Passing the full board instance will simplify `new Board()` construction if new fields are added in the future.
#### What are the relevant tickets?

Refs parallaxinc/ChromeIDE/issues/117
