### PR TITLE
Parse compile errors, expose module name

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -13,8 +13,7 @@ function internalCompile(source){
   var TModuleRec = bs2tokenizer.compile(source, false);
 
   if(!TModuleRec.Succeeded){
-    var error = bs2tokenizer.parseError(TModuleRec);
-    throw error;
+    throw TModuleRec.Error;
   }
 
   var memory = {

--- a/lib/board.js
+++ b/lib/board.js
@@ -13,11 +13,13 @@ function internalCompile(source){
   var TModuleRec = bs2tokenizer.compile(source, false);
 
   if(!TModuleRec.Succeeded){
-    throw new Error('Compile error: ' + TModuleRec.Error);
+    var error = bs2tokenizer.parseError(TModuleRec);
+    throw error;
   }
 
   var memory = {
-    data: TModuleRec.PacketBuffer.slice(0, TModuleRec.PacketCount * 18)
+    data: TModuleRec.PacketBuffer.slice(0, TModuleRec.PacketCount * 18),
+    moduleName: TModuleRec.TargetModuleName
   };
 
   return memory;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bs2-programmer": "^2.3.0",
     "bs2-serial-protocol": "^0.5.0",
     "lodash": "^3.5.0",
-    "pbasic-tokenizer": "^0.2.0",
+    "pbasic-tokenizer": "^0.3.0",
     "through2": "^0.6.5"
   }
 }


### PR DESCRIPTION
#### What's this PR do?

Uses updated tokenizer error when compiling. Exposes `moduleName` for automatic board detection.
#### What are the relevant tickets?

Depends on parallaxinc/PBASIC-Tokenizer/pull/12
parallaxinc/Parallax-IDE/issues/163
parallaxinc/Parallax-IDE/issues/132
