### PR TITLE
Compiler interface changes and search improvements

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -88,7 +88,7 @@ Board.search = function(portList, options, cb){
         };
         if(options.source){
           details.program = internalCompile(options.source);
-          details.match = !details.program.error && details.program.name === board.name;
+          details.match = details.program.name === board.name;
         }
         boardList.push(details);
       }

--- a/lib/board.js
+++ b/lib/board.js
@@ -84,16 +84,11 @@ Board.search = function(portList, options, cb){
           version: board.version,
           board: _.cloneDeep(board),
           match: false,
-          data: null
+          module: null
         };
         if(options.source){
-          var module = internalCompile(options.source);
-          if(!module.error && module.name === board.name){
-            _.assign(details, {
-              match: true,
-              data: module.data
-            });
-          }
+          details.module = internalCompile(options.source);
+          details.match = !details.module.error && details.module.name === board.name;
         }
         boardList.push(details);
       }
@@ -103,12 +98,15 @@ Board.search = function(portList, options, cb){
   }, []).nodeify(cb);
 };
 
-Board.prototype.bootload = function(memory, cb){
-  if(!memory || !memory.data){
-    throw new Error('Options error: no program data');
+Board.prototype.bootload = function(program, cb){
+  if(program && program.error){
+    return bluebird.reject(program.error).nodeify(cb);
+  }
+  if(!program || !program.data){
+    return bluebird.reject(new Error('Options error: no program data')).nodeify(cb);
   }
 
-  return this._programmer.bootload(memory.data, cb);
+  return this._programmer.bootload(program.data, cb);
 };
 
 Board.compile = function(source){

--- a/lib/board.js
+++ b/lib/board.js
@@ -91,7 +91,7 @@ Board.search = function(portList, options, cb){
           if(!module.error && module.name === board.name){
             _.assign(details, {
               match: true,
-              source: module.data
+              data: module.data
             });
           }
         }

--- a/lib/board.js
+++ b/lib/board.js
@@ -12,13 +12,13 @@ var Bs2SerialProtocol = require('bs2-serial-protocol');
 function internalCompile(source){
   var TModuleRec = bs2tokenizer.compile(source, false);
 
-  var module = {
+  var program = {
     data: TModuleRec.PacketBuffer.slice(0, TModuleRec.PacketCount * 18),
     name: TModuleRec.TargetModuleName,
     error: !TModuleRec.Succeeded ? TModuleRec.Error : null
   };
 
-  return module;
+  return program;
 }
 
 function Board(options){
@@ -84,11 +84,11 @@ Board.search = function(portList, options, cb){
           version: board.version,
           board: _.cloneDeep(board),
           match: false,
-          module: null
+          program: null
         };
         if(options.source){
-          details.module = internalCompile(options.source);
-          details.match = !details.module.error && details.module.name === board.name;
+          details.program = internalCompile(options.source);
+          details.match = !details.program.error && details.program.name === board.name;
         }
         boardList.push(details);
       }

--- a/lib/board.js
+++ b/lib/board.js
@@ -12,16 +12,13 @@ var Bs2SerialProtocol = require('bs2-serial-protocol');
 function internalCompile(source){
   var TModuleRec = bs2tokenizer.compile(source, false);
 
-  if(!TModuleRec.Succeeded){
-    throw TModuleRec.Error;
-  }
-
-  var memory = {
+  var module = {
     data: TModuleRec.PacketBuffer.slice(0, TModuleRec.PacketCount * 18),
-    moduleName: TModuleRec.TargetModuleName
+    name: TModuleRec.TargetModuleName,
+    error: !TModuleRec.Succeeded ? TModuleRec.Error : null
   };
 
-  return memory;
+  return module;
 }
 
 function Board(options){
@@ -55,7 +52,7 @@ function Board(options){
 
 util.inherits(Board, EventEmitter);
 
-Board.search = function(portList, cb){
+Board.search = function(portList, options, cb){
   var revisions = _.keys(bs2.revisions);
   return bluebird.reduce(portList, function(boardList, path){
 
@@ -81,12 +78,24 @@ Board.search = function(portList, cb){
     }, null)
     .then(function(board){
       if(board != null){
-        boardList.push({
+        var details = {
           name: board.name,
           path: board.path,
           version: board.version,
-          board: _.cloneDeep(board)
-        });
+          board: _.cloneDeep(board),
+          match: false,
+          data: null
+        };
+        if(options.source){
+          var module = internalCompile(options.source);
+          if(!module.error && module.name === board.name){
+            _.assign(details, {
+              match: true,
+              source: module.data
+            });
+          }
+        }
+        boardList.push(details);
       }
       return boardList;
     });
@@ -102,10 +111,8 @@ Board.prototype.bootload = function(memory, cb){
   return this._programmer.bootload(memory.data, cb);
 };
 
-Board.prototype.compile = function(source, cb){
-  var result = bluebird.try(internalCompile, source);
-
-  return result.nodeify(cb);
+Board.compile = function(source){
+  return internalCompile(source);
 };
 
 Board.prototype.isOpen = function(){


### PR DESCRIPTION
#### What's this PR do?

This PR changes how tokenization is handled, exposing it as a static method for general use. It also allows an optional source field in the board search `options` that allows for automatic matching boards based on `$STAMP` directive.
#### Any background context you want to provide?

There wasn't any reason to have `compile()` tied into the board prototype. This also cleans up and extends error handling within the `bootload` method, previously it would throw when a rejected promise was expected.
#### What are the relevant tickets?

parallaxinc/Parallax-IDE/issues/132
parallaxinc/Parallax-IDE/issues/164
