### PR TITLE
Convert strings to buffer in write method

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -118,7 +118,7 @@ Board.prototype.isOpen = function(){
 Board.prototype.write = function(data, cb){
   if(typeof data === 'number'){
     data = new Buffer([data]);
-  }else if(Array.isArray(data)){
+  }else if(Array.isArray(data) || typeof data === 'string'){
     data = new Buffer(data);
   }
   return this._protocol.write(data, cb);


### PR DESCRIPTION
#### What's this PR do?

Fixes issue where strings passed into `write` are not parsed by transmit pane stream implementation.
