### PR TITLE
support passing a string to bootload and having it compile

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -98,6 +98,9 @@ Board.search = function(portList, options, cb){
 };
 
 Board.prototype.bootload = function(program, cb){
+  if(typeof program === 'string'){
+    program = internalCompile(program);
+  }
   if(program && program.error){
     return bluebird.reject(program.error).nodeify(cb);
   }


### PR DESCRIPTION
#### What's this PR do?

Allows the end-user to pass a string as the `program` argument and automatically have it compiled by `bootload`.
#### What are the important parts of the code?

The `bootload` method.  The string check is done before everything else and compilation is reassigned to `program` so the other checks work.
#### How should this be tested by the reviewer?

Verify you can send a string to the `bootload` method/
#### Is any other information necessary to understand this?

We need to recompile the program after the source is changed when compiling for a different BS2.  This allows us to do that without any other steps.
