### PR TITLE
Move search implementation into board interface

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -23,6 +23,21 @@ function internalCompile(source){
   return program;
 }
 
+function generateEmptyPortlist(portList){
+  return _.map(portList, function(port){
+    return {
+      name: null,
+      path: port,
+      type: 'bs2',
+      match: false,
+      program: null,
+      board: {
+        path: port
+      }
+    };
+  });
+}
+
 function Board(options){
   if(!options){
     throw new Error('Options error: no options');
@@ -51,50 +66,80 @@ function Board(options){
 
 util.inherits(Board, EventEmitter);
 
-Board.search = function(portList, options, cb){
-  var revisions = _.keys(bs2.revisions);
-  return bluebird.reduce(portList, function(boardList, path){
-
-    var protocol = new Bs2SerialProtocol({ path: path });
-    return bluebird.reduce(revisions, function(current, rev){
-      if(current){
-        return current;
-      }
-
-      var boardOpts = {
-        protocol: protocol,
-        revision: rev
-      };
-
-      return bs2.identify(boardOpts)
-        .then(function(result){
-          return _.assign({ path: path, revision: rev }, result);
-        })
-        .otherwise(function(){
-          return null;
-        });
-
-    }, null)
-    .then(function(board){
-      if(board != null){
-        var details = {
-          name: board.name,
-          path: board.path,
-          version: board.version,
-          board: _.cloneDeep(board),
-          match: false,
-          program: null
-        };
-        if(options.source){
-          details.program = internalCompile(options.source);
-          details.match = details.program.name === board.name;
+Board.listPorts = function listPorts(options){
+  var reject = _.get(options, 'reject') || [];
+  var predicate = reject;
+  if(Array.isArray(reject)){
+    predicate = function(port){
+      return _.some(reject, function(entry){
+        if(typeof entry === 'string'){
+          return port === entry;
         }
-        boardList.push(details);
-      }
-      return boardList;
+        return entry.test(port);
+      });
+    };
+  }
+  return Bs2SerialProtocol.listPorts()
+    .then(function(portList){
+      return _.reject(portList, predicate);
     });
+};
 
-  }, []).nodeify(cb);
+Board.search = function(options, cb){
+  var revisions = _.keys(bs2.revisions);
+  return Board.listPorts(options)
+    .then(function(portList){
+    return bluebird.reduce(portList, function(boardList, path){
+
+      var protocol = new Bs2SerialProtocol({ path: path });
+      return bluebird.reduce(revisions, function(current, rev){
+        if(current){
+          return current;
+        }
+
+        var boardOpts = {
+          protocol: protocol,
+          revision: rev
+        };
+
+        return bs2.identify(boardOpts)
+          .then(function(result){
+            return _.assign({ path: path, revision: rev }, result);
+          })
+          .otherwise(function(){
+            return null;
+          });
+
+      }, null)
+      .then(function(board){
+        if(board != null){
+          var details = {
+            name: board.name,
+            path: board.path,
+            version: board.version,
+            board: _.cloneDeep(board),
+            match: false,
+            program: null
+          };
+          if(options.source){
+            details.program = internalCompile(options.source);
+            details.match = details.program.name === board.name;
+          }
+          boardList.push(details);
+        }
+        return boardList;
+      });
+
+    }, [])
+    .then(function(boards){
+      var allPorts = generateEmptyPortlist(portList);
+      var emptyPorts = _.reject(allPorts, function(ep){
+        return _.find(boards, { path: ep.path });
+      });
+      return boards.concat(emptyPorts);
+    })
+    .nodeify(cb);
+  });
 };
 
 Board.prototype.bootload = function(program, cb){

--- a/lib/board.js
+++ b/lib/board.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 var util = require('util');
 var bs2 = require('bs2-programmer');
+var nodefn = require('when/node');
 var bluebird = require('bluebird');
 var Bs2Programmer = bs2.Programmer;
 var reemit = require('re-emitter');
@@ -38,6 +39,25 @@ function generateEmptyPortlist(portList){
   });
 }
 
+function listPorts(options){
+  var reject = _.get(options, 'reject') || [];
+  var predicate = reject;
+  if(Array.isArray(reject)){
+    predicate = function(port){
+      return _.some(reject, function(entry){
+        if(typeof entry === 'string'){
+          return port === entry;
+        }
+        return entry.test(port);
+      });
+    };
+  }
+  return Bs2SerialProtocol.listPorts()
+    .then(function(portList){
+      return _.reject(portList, predicate);
+    });
+}
+
 function Board(options){
   if(!options){
     throw new Error('Options error: no options');
@@ -66,80 +86,61 @@ function Board(options){
 
 util.inherits(Board, EventEmitter);
 
-Board.listPorts = function listPorts(options){
-  var reject = _.get(options, 'reject') || [];
-  var predicate = reject;
-  if(Array.isArray(reject)){
-    predicate = function(port){
-      return _.some(reject, function(entry){
-        if(typeof entry === 'string'){
-          return port === entry;
-        }
-        return entry.test(port);
-      });
-    };
-  }
-  return Bs2SerialProtocol.listPorts()
-    .then(function(portList){
-      return _.reject(portList, predicate);
-    });
-};
-
 Board.search = function(options, cb){
   var revisions = _.keys(bs2.revisions);
-  return Board.listPorts(options)
+  var result = listPorts(options)
     .then(function(portList){
-    return bluebird.reduce(portList, function(boardList, path){
+      return bluebird.reduce(portList, function(boardList, path){
 
-      var protocol = new Bs2SerialProtocol({ path: path });
-      return bluebird.reduce(revisions, function(current, rev){
-        if(current){
-          return current;
-        }
-
-        var boardOpts = {
-          protocol: protocol,
-          revision: rev
-        };
-
-        return bs2.identify(boardOpts)
-          .then(function(result){
-            return _.assign({ path: path, revision: rev }, result);
-          })
-          .otherwise(function(){
-            return null;
-          });
-
-      }, null)
-      .then(function(board){
-        if(board != null){
-          var details = {
-            name: board.name,
-            path: board.path,
-            version: board.version,
-            board: _.cloneDeep(board),
-            match: false,
-            program: null
-          };
-          if(options.source){
-            details.program = internalCompile(options.source);
-            details.match = details.program.name === board.name;
+        var protocol = new Bs2SerialProtocol({ path: path });
+        return bluebird.reduce(revisions, function(current, rev){
+          if(current){
+            return current;
           }
-          boardList.push(details);
-        }
-        return boardList;
-      });
 
-    }, [])
-    .then(function(boards){
-      var allPorts = generateEmptyPortlist(portList);
-      var emptyPorts = _.reject(allPorts, function(ep){
-        return _.find(boards, { path: ep.path });
+          var boardOpts = {
+            protocol: protocol,
+            revision: rev
+          };
+
+          return bs2.identify(boardOpts)
+            .then(function(result){
+              return _.assign({ path: path, revision: rev }, result);
+            })
+            .otherwise(function(){
+              return null;
+            });
+
+        }, null)
+        .then(function(board){
+          if(board != null){
+            var details = {
+              name: board.name,
+              path: board.path,
+              version: board.version,
+              board: _.cloneDeep(board),
+              match: false,
+              program: null
+            };
+            if(options.source){
+              details.program = internalCompile(options.source);
+              details.match = details.program.name === board.name;
+            }
+            boardList.push(details);
+          }
+          return boardList;
+        });
+      }, [])
+      .then(function(boards){
+        var allPorts = generateEmptyPortlist(portList);
+        var emptyPorts = _.reject(allPorts, function(ep){
+          return _.find(boards, { path: ep.path });
+        });
+        return boards.concat(emptyPorts);
       });
-      return boards.concat(emptyPorts);
-    })
-    .nodeify(cb);
-  });
+    });
+
+  return nodefn.bindCallback(result, cb);
 };
 
 Board.prototype.bootload = function(program, cb){

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lodash": "^3.5.0",
     "pbasic-tokenizer": "^0.3.0",
     "re-emitter": "^1.1.1",
-    "through2": "^0.6.5"
+    "through2": "^0.6.5",
+    "when": "^3.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "bluebird": "^2.9.14",
     "bs2-programmer": "^2.3.0",
-    "bs2-serial-protocol": "^0.7.0",
+    "bs2-serial-protocol": "^0.8.0",
     "lodash": "^3.5.0",
     "pbasic-tokenizer": "^0.3.0",
     "re-emitter": "^1.1.1",


### PR DESCRIPTION
#### What's this PR do?

This PR implements the port list functionality for the board search into the board class.
#### Is any other information necessary to understand this?

This change allows Irken to no longer be serial-specific and removes a redundant serialport dependency.
#### What are the relevant tickets?

Depends on irkenjs/bs2-serialport/pull/14
