### PR TITLE
Add setEcho function and bump deps

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -186,6 +186,10 @@ Board.prototype.close = function(cb){
   return this._protocol.close(cb);
 };
 
+Board.prototype.setEcho = function(echo){
+  this._protocol.setEcho(echo);
+};
+
 Board.getRevisions = function(){
   return bs2.revisions;
 };

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "bluebird": "^2.9.14",
-    "bs2-programmer": "^2.3.2",
-    "bs2-serial-protocol": "^0.11.0",
+    "bs2-programmer": "^2.4.0",
+    "bs2-serial-protocol": "^0.12.0",
     "lodash": "^3.5.0",
     "pbasic-tokenizer": "^0.3.0",
     "re-emitter": "^1.1.1",


### PR DESCRIPTION
#### What's this PR do?

This adds a `setEcho` function to toggle the echo ignore feature in serial-protocol. It also bumps the dependencies for irkenjs/bs2-programmer/pull/18.
#### What are the relevant tickets?

Needed to resolve parallaxinc/Parallax-IDE/issues/185
